### PR TITLE
Add Support for IdentityDbContext by using SubClassOf

### DIFF
--- a/src/DotNetEd.CoreAdmin/CoreAdminConfigurationExtensions.cs
+++ b/src/DotNetEd.CoreAdmin/CoreAdminConfigurationExtensions.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             foreach(var service in services.ToList())
             {
-                if (service.ImplementationType?.BaseType == typeof(DbContext))
+                if (service.ImplementationType == null)
+                    continue;
+                if (service.ImplementationType.IsSubclassOf(typeof(DbContext)))
                 {
                     services.AddTransient(services => new DiscoveredDbContextType() { Type = service.ImplementationType }) ;
                 }

--- a/src/DotNetEd.CoreAdmin/DotNetEd.CoreAdmin.csproj
+++ b/src/DotNetEd.CoreAdmin/DotNetEd.CoreAdmin.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="NonFactors.Grid.Core.Mvc6" Version="6.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
+    <PackageReference Include="NonFactors.Grid.Core.Mvc6" Version="6.2.3" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Current discovery method does not allow for Data Contexts that inherit from IdentityDbContext. Using SubClassOf allows for better discovery. 

`service.ImplementationType?.IsSubclassOf(typeof(DbContext))` causes the following error, therefor the null check was added instead of using the Implicit Null Operator:
Cannot implicitly convert type 'bool?' to 'bool'. An explicit conversion exists (are you missing a cast?)
