### PR TITLE
Update CoreAdminConfigurationExtensions.cs FindDbContexts method to fix duplicated DbSets

### DIFF
--- a/src/DotNetEd.CoreAdmin/CoreAdminConfigurationExtensions.cs
+++ b/src/DotNetEd.CoreAdmin/CoreAdminConfigurationExtensions.cs
@@ -69,13 +69,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void FindDbContexts(IServiceCollection services)
         {
+            List<DiscoveredDbContextType> discoveredServices = new();
             foreach (var service in services.ToList())
             {
                 if (service.ImplementationType == null)
                     continue;
-                if (service.ImplementationType.IsSubclassOf(typeof(DbContext)))
-                {
-                    services.AddTransient(services => new DiscoveredDbContextType() { Type = service.ImplementationType });
+                if (service.ImplementationType.IsSubclassOf(typeof(DbContext)) && !discoveredServices.Any(x => x.Type == service.ImplementationType)){
+                    discoveredServices.Add(new DiscoveredDbContextType() { Type = service.ImplementationType });
+                    services.AddTransient(_ => new DiscoveredDbContextType() { Type = service.ImplementationType });
                 }
             }
         }

--- a/src/DotNetEd.CoreAdmin/CoreAdminConfigurationExtensions.cs
+++ b/src/DotNetEd.CoreAdmin/CoreAdminConfigurationExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void FindDbContexts(IServiceCollection services)
         {
-            List<DiscoveredDbContextType> discoveredServices = new();
+            var discoveredServices = new List<DiscoveredDbContextType>();
             foreach (var service in services.ToList())
             {
                 if (service.ImplementationType == null)


### PR DESCRIPTION
Hey @edandersen, here is a fix for the duplicated DbSets. I've tested it to work locally in my own project, but I would appreciate it if you can test it with the demo! :-)

<img width="227" alt="image" src="https://user-images.githubusercontent.com/26203420/130958794-29e68656-c07f-45d1-a430-aeecf9ce0a1c.png">

The fix was to check if the implementation type of discovered services already has been discovered before adding the `DiscoveredDbContextType` to the services.

Fixes #10