### PR TITLE
Update CoreAdminSecurityOptions.cs to support setting more than just IgnoreEntityTypes

### DIFF
--- a/src/DotNetEd.CoreAdmin/CoreAdminSecurityOptions.cs
+++ b/src/DotNetEd.CoreAdmin/CoreAdminSecurityOptions.cs
@@ -7,12 +7,12 @@ namespace DotNetEd.CoreAdmin
 {
     public class CoreAdminOptions
     {
-        public string[] RestrictToRoles { get; internal set; }
-        public Func<Task<bool>> CustomAuthorisationMethod { get; internal set; }
+        public string[] RestrictToRoles { get; set; }
+        public Func<Task<bool>> CustomAuthorisationMethod { get; set; }
         public bool IsSecuritySet => (RestrictToRoles != null && RestrictToRoles.Length > 0) || CustomAuthorisationMethod != null || CustomAuthorisationMethodWithServiceProvider != null;
 
-        public string CdnPath { get; internal set; }
-        public Func<IServiceProvider, Task<bool>> CustomAuthorisationMethodWithServiceProvider { get; internal set; }
+        public string CdnPath { get; set; }
+        public Func<IServiceProvider, Task<bool>> CustomAuthorisationMethodWithServiceProvider { get; set; }
         public IEnumerable<Type> IgnoreEntityTypes { get; set; } = new List<Type>();
     }
 }


### PR DESCRIPTION
Removed "internal set" as this restricts us from initializing anything other than the IgnoreEntityTypes.

I need to do this which was not possible:

```csharp
services.AddCoreAdmin(new CoreAdminOptions()
{
    RestrictToRoles = "Admin"
    IgnoreEntityTypes = new List<Type>() { typeof(PersistedGrant), typeof(DeviceFlowCodes) }
});
```