### PR TITLE
replace UseEndpoints with app.MapDefaultControllerRoute one liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,7 @@ builder.Services.AddCoreAdmin();
 You need to make sure Endpoints are enabled as they don't appear to be in the default templates. For example, add the following before ```app.Run();```:
 
 ```csharp
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllerRoute(
-        name: "default",
-        pattern: "{controller=Home}/{action=Index}/{id?}");
-
-});
+app.MapDefaultControllerRoute();
 ```
 
 ## How to use with .NET Core 3.1 and .NET 5 (version <2.0.0)

--- a/src/DotNetEd.CoreAdmin.DemoAppDotNet6/Program.cs
+++ b/src/DotNetEd.CoreAdmin.DemoAppDotNet6/Program.cs
@@ -32,12 +32,6 @@ app.UseAuthorization();
 app.MapRazorPages();
 
 // Required for Core Admin
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllerRoute(
-        name: "default",
-        pattern: "{controller=Home}/{action=Index}/{id?}");
-
-});
+app.MapDefaultControllerRoute();
 
 app.Run();


### PR DESCRIPTION
Can I suggest you replace the `app.UseEndpoints(...)` code in Program.cs with a nice `MapDefaultControllerRoute()` oneliner?

More info here [https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.controllerendpointroutebuilderextensions.mapdefaultcontrollerroute?view=aspnetcore-6.0](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.controllerendpointroutebuilderextensions.mapdefaultcontrollerroute?view=aspnetcore-6.0)

Thanks
John


