### PR TITLE
Update page heading with DbSetName and add warning banner

### DIFF
--- a/src/DotNetEd.CoreAdmin/Views/CoreAdminData/DeleteEntity.cshtml
+++ b/src/DotNetEd.CoreAdmin/Views/CoreAdminData/DeleteEntity.cshtml
@@ -3,16 +3,18 @@
 @{
     ViewData["Page_Title"] = Model.DbSetName;
     Layout = "_CoreAdminLayout";
+
+    string WarningMsg = "Are you sure you want to delete this?";
 }
 
-<h1 class="display-4">Are you sure you want to delete this?</h1>
+<h1 class="display-4">@Model.DbSetName - Delete</h1>
+<h5 class="text-warning mt-3"><span class="bg-info px-3 pb-1">@WarningMsg</span></h5>
 
 <div class="row my-3">
     <div class="col-lg-12">
         @Html.DisplayFor(m => m.Object)
     </div>
 </div>
-
 
 @using (Html.BeginForm("DeleteEntityPost", "CoreAdminData", new {}, FormMethod.Post))
 {


### PR DESCRIPTION
This branch was created from one of the last dotnet5 commits (v1.8.0) as I'm still targeting the .NET 5 framework.

Updated Delete Entity page heading to include DbSetName.
Moved existing page heading into a warning banner.

![core-admin-for-delete-entity](https://user-images.githubusercontent.com/20689043/160471773-9e0ab8ac-f708-44b3-8427-72c6864d561e.png)

![delete-entity-heading-banner](https://user-images.githubusercontent.com/20689043/160471809-42b52378-babc-4ec2-a64c-d2b68fce8248.png)

