### PR TITLE
Fixed a bug where having any non generic property in DbContext would cause the code to crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,4 @@ MigrationBackup/
 /src/DotNetEd.CoreAdmin/out/*
 /src/DotNetEd.CoreAdmin/out/*
 /src/DotNetEd.CoreAdmin/out/*
+.idea/

--- a/src/DotNetEd.CoreAdmin/Controllers/CoreAdminDataController.cs
+++ b/src/DotNetEd.CoreAdmin/Controllers/CoreAdminDataController.cs
@@ -94,7 +94,8 @@ namespace DotNetEd.CoreAdmin.Controllers
                                 var propsOnDbContext = dbContextObject.GetType().GetProperties();
 
                                 var targetChildListOnDbContext = dbContextObject.GetType().GetProperties()
-                                    .FirstOrDefault(p => p.PropertyType.GetGenericTypeDefinition() == typeof(DbSet<>)
+                                    .FirstOrDefault(p => p.PropertyType.IsGenericType
+                                    && p.PropertyType.GetGenericTypeDefinition() == typeof(DbSet<>)
                                     && p.PropertyType.GetGenericArguments().First().FullName == typeOfChild.PrincipalEntityType.Name);
 
                                 var primaryKey2 = dbContextObject.Model.FindEntityType(typeOfChild.PrincipalEntityType.Name).FindPrimaryKey();


### PR DESCRIPTION
Fix #77 

Added a condition to the query that causes the exception which filters any non-generic property before checking `GenericTypeDefinition`