### PR TITLE
Added support for rendering IEnumerable entities

### DIFF
--- a/src/DotNetEd.CoreAdmin/Controllers/CoreAdminDataController.cs
+++ b/src/DotNetEd.CoreAdmin/Controllers/CoreAdminDataController.cs
@@ -50,7 +50,7 @@ namespace DotNetEd.CoreAdmin.Controllers
                                 query = query.Include(property.Name);
                         }
 
-                        viewModel.Data = (IEnumerable<object>)query;
+                        viewModel.Data = query.ToArray();
                         viewModel.DbContext = dbContextObject;
                     }
                 }

--- a/src/DotNetEd.CoreAdmin/Views/CoreAdminData/Index.cshtml
+++ b/src/DotNetEd.CoreAdmin/Views/CoreAdminData/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@using DotNetEd.CoreAdmin
+﻿@using System.Collections
+@using DotNetEd.CoreAdmin
 @using Microsoft.Extensions.Localization
 @using NonFactors.Mvc.Grid
 @using System.Linq.Expressions
@@ -61,7 +62,27 @@
                         var base64 = ImageUtils.WebBase64EncodeImageByteArrayOrNull(lambda.Compile().Invoke(value));
                         return base64 == null ? string.Empty : $"<img height='48' src='{base64}'>";
                     } ).Encoded(false);
-            }   
+            }
+            else if (entityProperty.PropertyType.IsAssignableTo(typeof(IEnumerable)) && entityProperty.PropertyType != typeof(string))
+            {
+                var lambda = Expression.Lambda<Func<object, object>>(property, entity);
+
+                columns.Add(lambda).Titled(entityProperty.Name)
+                    .RenderedAs((value) =>
+                    {
+                        var finalString = "<ul>";
+                        try
+                        {
+                            foreach (var raw in (IEnumerable)entityProperty.GetValue(value)!)
+                            {
+                                finalString += $"<li><a href=\"{Url.Action("Index", new { id = raw.GetType().Name })}\">{raw}</a></li>";
+                            }
+                        }
+                        catch(NullReferenceException) {}
+                        finalString += "</ul>";
+                        return finalString;
+                    } ).Encoded(false);
+            }
              /*  if (entityProperty.PropertyType == typeof(Guid))
             {
                 var lambda = Expression.Lambda<Func<object,Guid>>(property, entity);


### PR DESCRIPTION
Consider the following case 

```cs
public class Category : BaseModel
{
    [Required] public string Name { get; set; }

    public int? ParentId { get; set; }
    public virtual Category Parent { get; set; }
    
    public virtual ICollection<Category> Children { get; set; }
    public virtual ICollection<Product> Products { get; set; }

    public override string ToString() => $"{Name} - {(ParentId == null ? "root" : "child")}";
}
```

Currently, navigation properties `Children` and `Products` cause the code to crash.
After inspecting the code I found that there is no support for rendering such properties.
So, I made the controller eager load the entities before sending them to the View to avoid the crash, then I added code in the view that should render these properties as `<ul>`