### PR TITLE
Switch from ImplementationType to ServiceType to support AddDbContextPool()

### DIFF
--- a/src/DotNetEd.CoreAdmin/CoreAdminConfigurationExtensions.cs
+++ b/src/DotNetEd.CoreAdmin/CoreAdminConfigurationExtensions.cs
@@ -118,12 +118,12 @@ namespace Microsoft.Extensions.DependencyInjection
             var discoveredServices = new List<DiscoveredDbSetEntityType>();
             foreach (var service in services.ToList())
             {
-                if (service.ImplementationType == null)
+                if (service.ServiceType == null)
                     continue;
-                if (service.ImplementationType.IsSubclassOf(typeof(DbContext)) && 
-                    !discoveredServices.Any(x => x.DbContextType == service.ImplementationType))
+                if (service.ServiceType.IsSubclassOf(typeof(DbContext)) && 
+                    !discoveredServices.Any(x => x.DbContextType == service.ServiceType))
                 {
-                    foreach (var dbSetProperty in service.ImplementationType.GetProperties())
+                    foreach (var dbSetProperty in service.ServiceType.GetProperties())
                     {
                         // looking for DbSet<Entity>
                         if (dbSetProperty.PropertyType.IsGenericType && dbSetProperty.PropertyType.Name.StartsWith("DbSet"))
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.DependencyInjection
                             if (!options.IgnoreEntityTypes.Contains(dbSetProperty.PropertyType.GenericTypeArguments.First()))
                             {
                                 discoveredServices.Add(new DiscoveredDbSetEntityType() { 
-                                    DbContextType = service.ImplementationType, 
+                                    DbContextType = service.ServiceType, 
                                     DbSetType = dbSetProperty.PropertyType, 
                                     UnderlyingType = dbSetProperty.PropertyType.GenericTypeArguments.First(), Name = dbSetProperty.Name });
                             }


### PR DESCRIPTION
Previously, CoreAdmin would not detect tables from a DbContext configured with AddDbContextPool(). This was because AddDbContextPool() sets service.ImplementationFactory instead of service.ImplementationType.

This pull request is a minimal set of changes based on #119.  It is similar to #96, with a couple simplifications:
- This PR does not include the "ServiceLifetime.Scoped" check (not sure why/if that was needed)
- This PR leaves the code to prevent duplicates in the detectedServices list.

I tested locally with an ASP.NET 10 / EF Core 10 project and found this change allows CoreAdmin to function with AddDbContextPool().